### PR TITLE
Fix Issue #27: Add fallback handling when MCP generateMoveOptions returns empty

### DIFF
--- a/packages/mcp-server/src/tools/game-execute.ts
+++ b/packages/mcp-server/src/tools/game-execute.ts
@@ -433,6 +433,16 @@ export class GameExecuteTool {
           // Update message to indicate pending effect
           const stepText = step ? ` - Step ${step}` : '';
           response.message = `Card requires choice: ${pendingEffect.card}${stepText}`;
+        } else {
+          // Fallback: Options generation not implemented for this effect type
+          // Provide raw valid moves so LLM can still attempt to make progress
+          response.pendingEffect = {
+            card: pendingEffect.card,
+            effect: pendingEffect.effect,
+            error: 'Options generation not implemented for this effect type',
+            validMoves: validMovesForOptions.map(m => formatMoveCommand(m))
+          };
+          response.message = `Warning: Card requires choice but option generation is incomplete. Card: ${pendingEffect.card}, Effect: ${pendingEffect.effect}. Try using raw move commands.`;
         }
       }
 

--- a/packages/mcp-server/src/types/tools.ts
+++ b/packages/mcp-server/src/types/tools.ts
@@ -53,11 +53,14 @@ export interface GameExecuteResponse {
     card: string;
     effect: string;
     step?: number;
-    options: Array<{
+    options?: Array<{
       index: number;
       description: string;
       command: string;
     }>;
+    // Fallback fields when option generation is not implemented
+    error?: string;
+    validMoves?: string[];
   };
   error?: {
     message: string;


### PR DESCRIPTION
When generateMoveOptions returns an empty array (due to missing effect type
handlers), the MCP server now provides a fallback response instead of omitting
the pendingEffect entirely.

Changes:
- Modified GameExecuteResponse type to support fallback fields:
  - Made options field optional
  - Added error field for fallback error message
  - Added validMoves field for raw move commands

- Added else clause in game-execute.ts to handle empty options:
  - Still adds pendingEffect to response with card and effect info
  - Includes error message explaining the issue
  - Provides validMoves array with raw command strings
  - Sets warning message to inform LLM of incomplete option generation

Impact:
- LLM agents will now be aware when there's a pending choice
- LLM can attempt to use raw move commands as fallback
- Prevents game from appearing stuck when option generation is incomplete

Related Issues:
- Fixes #27 (HIGH severity)
- Related to #21, #22, #23, #24 (missing effect handlers that trigger this)

Files Modified:
- packages/mcp-server/src/types/tools.ts: Updated GameExecuteResponse type
- packages/mcp-server/src/tools/game-execute.ts: Added fallback handling logic