### PR TITLE
Fix Issue #10: Bureaucrat targeting wrong player in move options

### DIFF
--- a/packages/core/src/presentation/move-options.ts
+++ b/packages/core/src/presentation/move-options.ts
@@ -819,7 +819,10 @@ export function generateMoveOptions(
       return [];
 
     case 'reveal_and_topdeck':
-      return generateBureaucratOptions(player.hand);
+      // Use targetPlayer from pendingEffect (Bureaucrat affects opponent, not current player)
+      const targetPlayerIndex = pendingEffect.targetPlayer ?? state.currentPlayer;
+      const targetPlayer = state.players[targetPlayerIndex];
+      return generateBureaucratOptions(targetPlayer.hand);
 
     default:
       console.warn(`generateMoveOptions: Unknown effect type: ${pendingEffect.effect}`);

--- a/packages/core/tests/presentation-move-options.test.ts
+++ b/packages/core/tests/presentation-move-options.test.ts
@@ -7,7 +7,7 @@
  * CLI and MCP interfaces to generate interactive card move options.
  */
 
-import { CardName } from '../src/types';
+import { CardName, GameState } from '../src/types';
 
 // NOTE: These imports will fail until implementation is created
 // This is EXPECTED and CORRECT in TDD red phase
@@ -877,6 +877,52 @@ describe('generateMoveOptions (Main Dispatcher)', () => {
     const options = generateMoveOptions(state, []);
 
     expect(options).toEqual([]);
+  });
+
+  it('should use targetPlayer hand for reveal_and_topdeck (Bureaucrat)', () => {
+    // @req: Issue #10 fix - Bureaucrat should use target player's hand, not current player's hand
+    // @assert: generateMoveOptions returns options based on targetPlayer's hand
+    const state: GameState = {
+      players: [
+        {
+          hand: ['Copper', 'Silver'], // Current player (P0) has no Victory cards
+          drawPile: [],
+          discardPile: [],
+          inPlay: [],
+          actions: 0,
+          buys: 0,
+          coins: 0
+        },
+        {
+          hand: ['Estate', 'Duchy', 'Copper'], // Target player (P1) has Victory cards
+          drawPile: [],
+          discardPile: [],
+          inPlay: [],
+          actions: 0,
+          buys: 0,
+          coins: 0
+        }
+      ],
+      currentPlayer: 0,
+      phase: 'action',
+      supply: new Map(),
+      trash: [],
+      turnNumber: 1,
+      seed: 'test',
+      gameLog: [],
+      pendingEffect: {
+        card: 'Bureaucrat',
+        effect: 'reveal_and_topdeck',
+        targetPlayer: 1 // Important: targeting player 1, not current player
+      }
+    };
+
+    const options = generateMoveOptions(state, []);
+
+    // Should have 2 options: Estate and Duchy (from player 1's hand, not player 0's)
+    expect(options.length).toBe(2);
+    expect(options[0].description).toBe('Topdeck: Estate');
+    expect(options[1].description).toBe('Topdeck: Duchy');
   });
 });
 


### PR DESCRIPTION
## Problem
Bureaucrat card was showing current player's hand instead of target
opponent's hand when generating move options. This caused:
1. Wrong cards displayed in CLI/MCP prompts
2. Input validation errors (options based on wrong player's cards)
3. Confused user experience

## Root Cause
In `generateMoveOptions()`, the `reveal_and_topdeck` case used
`player.hand` (current player) instead of checking `pendingEffect.targetPlayer`
to get the correct opponent's hand.

## Solution
- Updated `generateMoveOptions()` to use `pendingEffect.targetPlayer` for Bureaucrat effect
- Falls back to `currentPlayer` if targetPlayer not set (defensive coding)
- Added verification test confirming fix works correctly

## Changes
- `packages/core/src/presentation/move-options.ts`: Use targetPlayer for reveal_and_topdeck
- `packages/core/tests/presentation-move-options.test.ts`: Add test verifying targetPlayer behavior

## Testing
- All existing tests pass (84/84 in presentation-move-options)
- New test confirms targetPlayer hand is used correctly
- Bureaucrat attack tests pass (16/16)

Fixes #10