### PR TITLE
Resolve highest priority issue in principality_ai

### DIFF
--- a/packages/core/src/game.ts
+++ b/packages/core/src/game.ts
@@ -584,14 +584,22 @@ export class GameEngine {
   private endPhase(state: GameState): GameState {
     switch (state.phase) {
       case 'action':
-        return { ...state, phase: 'buy' };
-      
+        return {
+          ...state,
+          phase: 'buy',
+          gameLog: [...state.gameLog, `Player ${state.currentPlayer + 1} ended action phase`]
+        };
+
       case 'buy':
-        return { ...state, phase: 'cleanup' };
-      
+        return {
+          ...state,
+          phase: 'cleanup',
+          gameLog: [...state.gameLog, `Player ${state.currentPlayer + 1} ended buy phase`]
+        };
+
       case 'cleanup':
         return this.performCleanup(state);
-      
+
       default:
         throw new Error(`Cannot end unknown phase: ${state.phase}`);
     }


### PR DESCRIPTION
**Root Cause (Display Bug):**
When ending action or buy phase, no log entry was added to gameLog. CLI's executeMove() displays the last log entry, which showed stale messages from previous moves (e.g., "played Copper" from earlier).

**Solution:**
Add descriptive log entries in endPhase() for action→buy and buy→cleanup transitions. This ensures CLI always displays accurate phase end messages.

**Changes:**
- packages/core/src/game.ts:
  - endPhase(): Add gameLog entries for action and buy phase ends

**Impact:**
- Fixes confusing UX where "End Phase" appeared to execute wrong moves
- Phase transitions still work correctly (execution was never broken)
- Only affects display - game logic unchanged

**Testing:**
- Core game tests: 64/64 passing
- Phase transition logic verified correct
- No regressions in game mechanics

Closes #13