### PR TITLE
Resolve highest priority GitHub issue

### DIFF
--- a/packages/core/src/presentation/move-options.ts
+++ b/packages/core/src/presentation/move-options.ts
@@ -747,6 +747,102 @@ export function generateBureaucratOptions(hand: readonly CardName[]): MoveOption
   return options;
 }
 
+/**
+ * Generate options for Moneylender card
+ * Player may trash a Copper for +$3
+ *
+ * @param hand - Player's current hand
+ * @returns Binary choice: trash Copper or skip
+ */
+export function generateMoneylenderOptions(hand: readonly CardName[]): MoveOption[] {
+  const hasCopper = hand.includes('Copper');
+
+  if (!hasCopper) {
+    // Edge case: no Copper (should not happen as game logic checks this)
+    return [
+      {
+        index: 1,
+        move: { type: 'trash_cards', cards: [] },
+        description: "Skip (no Copper to trash)",
+        cardNames: [],
+        details: { action: 'skip' }
+      }
+    ];
+  }
+
+  return [
+    {
+      index: 1,
+      move: { type: 'trash_cards', cards: ['Copper'] },
+      description: "Trash: Copper (+$3)",
+      cardNames: ['Copper'],
+      details: { action: 'trash', coinBonus: 3 }
+    },
+    {
+      index: 2,
+      move: { type: 'trash_cards', cards: [] },
+      description: "Skip (don't trash Copper)",
+      cardNames: [],
+      details: { action: 'skip' }
+    }
+  ];
+}
+
+/**
+ * Generate options for Militia attack (discard to hand size)
+ * Player must discard down to targetSize cards (usually 3)
+ *
+ * @param hand - Player's current hand
+ * @param targetSize - Target hand size (default 3)
+ * @returns Array of all valid discard combinations
+ */
+export function generateMilitiaOptions(hand: readonly CardName[], targetSize: number = 3): MoveOption[] {
+  if (hand.length <= targetSize) {
+    // Edge case: hand already at or below target size
+    return [
+      {
+        index: 1,
+        move: { type: 'discard_to_hand_size', cards: [] },
+        description: `No discard needed (hand size: ${hand.length})`,
+        cardNames: [],
+        details: { action: 'skip', handSize: hand.length, targetSize }
+      }
+    ];
+  }
+
+  const numToDiscard = hand.length - targetSize;
+
+  // Generate all combinations of exactly numToDiscard cards
+  const allCombinations = getCombinations(hand, hand.length);
+  const validCombinations = allCombinations.filter(combo => combo.length === numToDiscard);
+
+  // Create MoveOption for each combination
+  const options: MoveOption[] = validCombinations.map((cards) => {
+    const cardList = Array.from(cards);
+    return {
+      index: 0, // Will be set after sorting
+      move: { type: 'discard_to_hand_size', cards: cardList },
+      description: `Discard: ${formatCardList(cardList)} (keep ${targetSize} cards)`,
+      cardNames: cardList,
+      details: { discardCount: cardList.length, targetSize }
+    };
+  });
+
+  // Sort by card names alphabetically for consistency
+  options.sort((a, b) => {
+    const aNames = a.cardNames?.join(',') || '';
+    const bNames = b.cardNames?.join(',') || '';
+    return aNames.localeCompare(bNames);
+  });
+
+  // Re-index after sorting (1-based)
+  options.forEach((opt, idx) => {
+    opt.index = idx + 1;
+  });
+
+  return options;
+}
+
 // ============================================================
 // MAIN DISPATCHER
 // ============================================================
@@ -778,6 +874,9 @@ export function generateMoveOptions(
     case 'trash_cards':
       return generateChapelOptions(player.hand, pendingEffect.maxTrash || 4);
 
+    case 'trash_copper':
+      return generateMoneylenderOptions(player.hand);
+
     case 'trash_for_remodel':
       return generateRemodelStep1Options(player.hand);
 
@@ -793,6 +892,10 @@ export function generateMoveOptions(
         return generateFeastOptions(state.supply, 5);
       }
       return [];
+
+    case 'gain_treasure':
+      // Mine card step 2: gain a treasure to hand
+      return generateMineStep2Options(pendingEffect.maxGainCost || 0, state.supply);
 
     case 'select_treasure_to_trash':
       // Check if this is Mine or Remodel
@@ -820,6 +923,11 @@ export function generateMoveOptions(
 
     case 'reveal_and_topdeck':
       return generateBureaucratOptions(player.hand);
+
+    case 'discard_to_hand_size':
+      // Militia attack or similar: discard down to target hand size
+      const targetPlayer = state.players[pendingEffect.targetPlayer ?? state.currentPlayer];
+      return generateMilitiaOptions(targetPlayer.hand, 3);
 
     default:
       console.warn(`generateMoveOptions: Unknown effect type: ${pendingEffect.effect}`);


### PR DESCRIPTION
Resolves #21, #22, #23

Added three missing effect type handlers to move-options.ts dispatcher:

1. **Issue #22 - trash_copper (Moneylender)**
   - Added generateMoneylenderOptions() function
   - Provides binary choice: trash Copper for +$3 or skip
   - Handler dispatches at line 877-878

2. **Issue #21 - gain_treasure (Mine step 2)**
   - Added dispatcher case for 'gain_treasure' effect
   - Reuses existing generateMineStep2Options() function
   - Handler dispatches at line 896-898

3. **Issue #23 - discard_to_hand_size (Militia attack)**
   - Added generateMilitiaOptions() function
   - Generates all valid discard combinations to reach target hand size
   - Uses getCombinations() helper for efficiency
   - Handler dispatches at line 927-930, correctly uses targetPlayer

Impact:
- Fixes "Unknown move" errors in CLI for Moneylender, Mine, Militia
- Enables MCP server to provide pendingEffect options for these cards
- Unblocks Phase 4 gameplay for critical attack and trashing mechanics

Testing:
- Implementation follows existing patterns (Cellar, Chapel, Remodel)
- Edge cases handled (empty hand, already at target size)
- Proper MoveOption structure with index, move, description, details