### PR TITLE
Resolve highest priority issue from principality_ai

### DIFF
--- a/packages/core/src/game.ts
+++ b/packages/core/src/game.ts
@@ -1495,12 +1495,14 @@ export class GameEngine {
     }
 
     // Set up pending effect for first player with cards
+    const revealedCard = newState.players[firstPlayer].drawPile[0];
     return {
       ...newState,
       pendingEffect: {
         card: 'Spy',
         effect: 'spy_decision',
-        targetPlayer: firstPlayer
+        targetPlayer: firstPlayer,
+        revealedCard: revealedCard
       },
       gameLog: [...newState.gameLog, `Player ${newState.currentPlayer + 1} played Spy (revealing top cards)`]
     };
@@ -1542,11 +1544,13 @@ export class GameEngine {
       }
 
       if (nextPlayer < state.players.length) {
+        const nextRevealedCard = state.players[nextPlayer].drawPile[0];
         return {
           ...state,
           pendingEffect: {
             ...state.pendingEffect,
-            targetPlayer: nextPlayer
+            targetPlayer: nextPlayer,
+            revealedCard: nextRevealedCard
           },
           gameLog: [...state.gameLog, `Player ${playerIndex + 1} has no cards to reveal for Spy`]
         };
@@ -1604,11 +1608,13 @@ export class GameEngine {
     // Update or clear pending effect
     if (nextPlayer < newState.players.length) {
       // More players to process
+      const nextRevealedCard = newState.players[nextPlayer].drawPile[0];
       return {
         ...newState,
         pendingEffect: {
           ...state.pendingEffect,
-          targetPlayer: nextPlayer
+          targetPlayer: nextPlayer,
+          revealedCard: nextRevealedCard
         }
       };
     } else {

--- a/packages/core/src/presentation/move-options.ts
+++ b/packages/core/src/presentation/move-options.ts
@@ -939,8 +939,11 @@ export function generateMoveOptions(
       return generateChancellorOptions(player.drawPile.length);
 
     case 'spy_decision':
-      // Need revealed card and target player from pendingEffect
-      return [];
+      if (!pendingEffect.revealedCard || pendingEffect.targetPlayer === undefined) {
+        console.warn('spy_decision missing required pendingEffect data (revealedCard, targetPlayer)');
+        return [];
+      }
+      return generateSpyOptions(pendingEffect.revealedCard, pendingEffect.targetPlayer);
 
     case 'reveal_and_topdeck':
       // Use targetPlayer from pendingEffect (Bureaucrat affects opponent, not current player)
@@ -950,8 +953,8 @@ export function generateMoveOptions(
 
     case 'discard_to_hand_size':
       // Militia attack or similar: discard down to target hand size
-      const targetPlayer = state.players[pendingEffect.targetPlayer ?? state.currentPlayer];
-      return generateMilitiaOptions(targetPlayer.hand, 3);
+      const militiaTarget = state.players[pendingEffect.targetPlayer ?? state.currentPlayer];
+      return generateMilitiaOptions(militiaTarget.hand, 3);
 
     default:
       console.warn(`generateMoveOptions: Unknown effect type: ${pendingEffect.effect}`);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -41,6 +41,7 @@ export interface PendingEffect {
   throneRoomDouble?: boolean;
   destination?: 'hand' | 'discard' | 'topdeck';  // For Mine and other cards that gain to specific location
   deckSize?: number;  // For Chancellor decision
+  revealedCard?: CardName;  // For Spy decision - card revealed from top of deck
 }
 
 export interface GameState {


### PR DESCRIPTION
## Problem
The spy_decision case in generateMoveOptions returned an empty array because the pendingEffect didn't include the revealed card information needed by generateSpyOptions.

## Solution
1. Added revealedCard property to PendingEffect interface
2. Updated handleSpy to include the revealed card in pendingEffect
3. Updated handleSpyDecision to maintain revealedCard when transitioning between players
4. Updated the spy_decision dispatcher to extract revealedCard and targetPlayer from pendingEffect and pass them to generateSpyOptions
5. Fixed variable name conflict (targetPlayer declared twice)

## Changes
- packages/core/src/types.ts:44 - Added revealedCard?: CardName
- packages/core/src/game.ts:1498 - Include revealedCard in initial pendingEffect
- packages/core/src/game.ts:1547,1611 - Update revealedCard when moving to next player
- packages/core/src/presentation/move-options.ts:941-946 - Use revealedCard and targetPlayer
- packages/core/src/presentation/move-options.ts:956 - Renamed variable to avoid conflict

## Testing
All Spy-related tests pass:
- UT-SPY-1, UT-SPY-2, UT-SPY-3 (unit tests)
- IT-ATTACK-3 (integration test with Spy)
- Presentation layer tests (85/85 passing)

Fixes #24