### PR TITLE
Resolve highest priority GitHub issue

### DIFF
--- a/packages/core/src/cards.ts
+++ b/packages/core/src/cards.ts
@@ -115,8 +115,8 @@ export const KINGDOM_CARDS: Record<CardName, Card> = {
     name: 'Council Room',
     type: 'action',
     cost: 5,
-    effect: { cards: 4, buys: 1 },
-    description: '+4 Cards, +1 Buy'
+    effect: { cards: 4, buys: 1, special: 'each_other_player_draws_1' },
+    description: '+4 Cards, +1 Buy. Each other player draws 1 card.'
   },
   'Cellar': {
     name: 'Cellar',

--- a/packages/core/src/game.ts
+++ b/packages/core/src/game.ts
@@ -1105,6 +1105,10 @@ export class GameEngine {
           gameLog: [...baseState.gameLog, `Player ${baseState.currentPlayer + 1} played Moat`]
         };
 
+      // === Beneficial Effects to Other Players ===
+      case 'each_other_player_draws_1': // Council Room
+        return this.handleCouncilRoom(baseState);
+
       // === Special Cards ===
       case 'play_action_twice': // Throne Room
         return {
@@ -1450,6 +1454,44 @@ export class GameEngine {
           : p
       ),
       gameLog: [...state.gameLog, `Player ${state.currentPlayer + 1} drew to 7 cards (Library)`]
+    };
+  }
+
+  private handleCouncilRoom(state: GameState): GameState {
+    // Council Room: +4 Cards and +1 Buy (already applied in standard effects)
+    // Each other player draws 1 card
+    let newState = state;
+
+    // Make all other players draw 1 card
+    for (let i = 0; i < state.players.length; i++) {
+      if (i === state.currentPlayer) continue; // Skip current player
+
+      const opponent = newState.players[i];
+
+      // Draw 1 card for this opponent
+      const drawResult = this.drawCards(opponent.drawPile, opponent.discardPile, opponent.hand, 1);
+
+      const updatedPlayers = newState.players.map((p, idx) =>
+        idx === i
+          ? {
+              ...p,
+              hand: drawResult.newHand,
+              drawPile: drawResult.newDeck,
+              discardPile: drawResult.newDiscard
+            }
+          : p
+      );
+
+      newState = {
+        ...newState,
+        players: updatedPlayers,
+        gameLog: [...newState.gameLog, `Player ${i + 1} drew 1 card`]
+      };
+    }
+
+    return {
+      ...newState,
+      gameLog: [...newState.gameLog, `Player ${newState.currentPlayer + 1} played Council Room`]
     };
   }
 

--- a/packages/core/tests/cards-council-room.test.ts
+++ b/packages/core/tests/cards-council-room.test.ts
@@ -1,0 +1,194 @@
+import { GameEngine, GameState } from '@principality/core';
+
+/**
+ * Phase 4 Unit Tests: Council Room Other Player Draw
+ * Related Issue: #6
+ *
+ * @req: Council Room should cause each other player to draw a card
+ * @level: Unit
+ * @count: 4 tests total
+ *
+ * Card under test:
+ * - Council Room ($5): +4 Cards, +1 Buy. Each other player draws 1 card.
+ */
+
+describe('UT: Council Room - Other Player Draw Effect', () => {
+  let engine: GameEngine;
+
+  beforeEach(() => {
+    engine = new GameEngine('council-room-test');
+  });
+
+  describe('UT-COUNCIL-ROOM: Other players draw 1 card', () => {
+    /**
+     * UT-COUNCIL-ROOM-1: Grant current player +4 Cards and +1 Buy
+     * @req: Council Room grants +4 Cards and +1 Buy to current player
+     * @assert: hand size increased by 4 (minus the played card = +3 net), buys += 1
+     */
+    test('UT-COUNCIL-ROOM-1: should grant current player +4 Cards and +1 Buy', () => {
+      // @req: Council Room grants +4 Cards, +1 Buy to current player
+      const state = engine.initializeGame(2);
+
+      const testState: GameState = {
+        ...state,
+        phase: 'action',
+        currentPlayer: 0,
+        players: [
+          {
+            ...state.players[0],
+            hand: ['Council Room', 'Copper'],
+            drawPile: ['Silver', 'Gold', 'Estate', 'Duchy', 'Province'],
+            actions: 1,
+            buys: 1
+          },
+          state.players[1]
+        ]
+      };
+
+      const result = engine.executeMove(testState, {
+        type: 'play_action',
+        card: 'Council Room'
+      });
+
+      expect(result.success).toBe(true);
+      // Hand: Started with 2, played 1, drew 4 = 5 total
+      expect(result.newState!.players[0].hand.length).toBe(5);
+      expect(result.newState!.players[0].buys).toBe(2); // 1 + 1
+      expect(result.newState!.players[0].hand).toContain('Copper');
+      expect(result.newState!.players[0].hand).toContain('Silver');
+      expect(result.newState!.players[0].hand).toContain('Gold');
+      expect(result.newState!.players[0].hand).toContain('Estate');
+      expect(result.newState!.players[0].hand).toContain('Duchy');
+    });
+
+    /**
+     * UT-COUNCIL-ROOM-2: Opponent draws 1 card in 2-player game
+     * @req: Each other player draws 1 card
+     * @assert: opponent hand size increased by 1
+     */
+    test('UT-COUNCIL-ROOM-2: should make opponent draw 1 card in 2-player game', () => {
+      // @req: Each other player draws 1 card
+      const state = engine.initializeGame(2);
+
+      const testState: GameState = {
+        ...state,
+        phase: 'action',
+        currentPlayer: 0,
+        players: [
+          {
+            ...state.players[0],
+            hand: ['Council Room'],
+            drawPile: ['Copper', 'Copper', 'Copper', 'Copper'],
+            actions: 1
+          },
+          {
+            ...state.players[1],
+            hand: ['Copper', 'Estate'],
+            drawPile: ['Silver', 'Gold', 'Province']
+          }
+        ]
+      };
+
+      const result = engine.executeMove(testState, {
+        type: 'play_action',
+        card: 'Council Room'
+      });
+
+      expect(result.success).toBe(true);
+      // Opponent (Player 1) should have drawn 1 card
+      expect(result.newState!.players[1].hand.length).toBe(3); // 2 + 1 = 3
+      expect(result.newState!.players[1].hand).toContain('Silver'); // Top card from deck
+    });
+
+    /**
+     * UT-COUNCIL-ROOM-3: All opponents draw 1 card in multiplayer game
+     * @req: Each other player draws 1 card (applies to all opponents)
+     * @assert: both opponents draw 1 card each
+     */
+    test('UT-COUNCIL-ROOM-3: should make all opponents draw 1 card in 3-player game', () => {
+      // @req: Each other player draws 1 card
+      const state = engine.initializeGame(3);
+
+      const testState: GameState = {
+        ...state,
+        phase: 'action',
+        currentPlayer: 0,
+        players: [
+          {
+            ...state.players[0],
+            hand: ['Council Room'],
+            drawPile: ['Copper', 'Copper', 'Copper', 'Copper'],
+            actions: 1
+          },
+          {
+            ...state.players[1],
+            hand: ['Copper'],
+            drawPile: ['Silver', 'Estate']
+          },
+          {
+            ...state.players[2],
+            hand: ['Estate'],
+            drawPile: ['Gold', 'Duchy']
+          }
+        ]
+      };
+
+      const result = engine.executeMove(testState, {
+        type: 'play_action',
+        card: 'Council Room'
+      });
+
+      expect(result.success).toBe(true);
+      // Player 1 should have drawn 1 card
+      expect(result.newState!.players[1].hand.length).toBe(2); // 1 + 1 = 2
+      expect(result.newState!.players[1].hand).toContain('Silver');
+
+      // Player 2 should have drawn 1 card
+      expect(result.newState!.players[2].hand.length).toBe(2); // 1 + 1 = 2
+      expect(result.newState!.players[2].hand).toContain('Gold');
+    });
+
+    /**
+     * UT-COUNCIL-ROOM-4: Opponents draw even if their deck is empty
+     * @req: Opponent draws work with shuffling discard pile
+     * @edge: Opponent has empty deck but cards in discard
+     * @assert: opponent draws from shuffled discard pile
+     */
+    test('UT-COUNCIL-ROOM-4: should handle opponent drawing when deck is empty', () => {
+      // @req: Draw mechanics work correctly with shuffle
+      const state = engine.initializeGame(2);
+
+      const testState: GameState = {
+        ...state,
+        phase: 'action',
+        currentPlayer: 0,
+        players: [
+          {
+            ...state.players[0],
+            hand: ['Council Room'],
+            drawPile: ['Copper', 'Copper', 'Copper', 'Copper'],
+            actions: 1
+          },
+          {
+            ...state.players[1],
+            hand: ['Copper'],
+            drawPile: [], // Empty deck
+            discardPile: ['Silver', 'Gold', 'Estate'] // Cards in discard
+          }
+        ]
+      };
+
+      const result = engine.executeMove(testState, {
+        type: 'play_action',
+        card: 'Council Room'
+      });
+
+      expect(result.success).toBe(true);
+      // Opponent should have drawn 1 card from shuffled discard
+      expect(result.newState!.players[1].hand.length).toBe(2); // 1 + 1 = 2
+      // Discard should be shuffled into deck
+      expect(result.newState!.players[1].drawPile.length).toBe(2); // 3 - 1 drawn = 2
+      expect(result.newState!.players[1].discardPile.length).toBe(0); // All shuffled
+    });
+  });
+});


### PR DESCRIPTION
## Problem
Council Room was missing the "Each other player draws 1 card" effect. Only the current player's +4 Cards and +1 Buy were working.

## Solution
1. Updated card definition to include special: 'each_other_player_draws_1'
2. Added handleCouncilRoom() method to make all other players draw 1 card
3. Updated card description to match official requirements

## Changes
- packages/core/src/cards.ts: Added special effect and updated description
- packages/core/src/game.ts: Implemented handleCouncilRoom() handler
- packages/core/tests/cards-council-room.test.ts: Added 4 comprehensive tests

## Tests
- UT-COUNCIL-ROOM-1: Current player gets +4 Cards and +1 Buy
- UT-COUNCIL-ROOM-2: Opponent draws 1 card in 2-player game
- UT-COUNCIL-ROOM-3: All opponents draw in 3-player game
- UT-COUNCIL-ROOM-4: Handles deck shuffling correctly

Fixes #6