### PR TITLE
Resolve highest priority GitHub issue

### DIFF
--- a/packages/core/src/presentation/move-options.ts
+++ b/packages/core/src/presentation/move-options.ts
@@ -416,10 +416,10 @@ export function generateRemodelStep2Options(
     ];
   }
 
-  // Sort by cost descending, then alphabetically
+  // Sort by cost ascending, then alphabetically
   availableCards.sort((a, b) => {
     if (a.cost !== b.cost) {
-      return b.cost - a.cost; // Higher cost first
+      return a.cost - b.cost; // Lower cost first
     }
     return a.name.localeCompare(b.name); // Alphabetical
   });
@@ -508,10 +508,10 @@ export function generateMineStep2Options(
     ];
   }
 
-  // Sort by cost descending, then alphabetically
+  // Sort by cost ascending, then alphabetically
   availableTreasures.sort((a, b) => {
     if (a.cost !== b.cost) {
-      return b.cost - a.cost; // Higher cost first
+      return a.cost - b.cost; // Lower cost first
     }
     return a.name.localeCompare(b.name); // Alphabetical
   });
@@ -562,10 +562,10 @@ export function generateWorkshopOptions(
     ];
   }
 
-  // Sort by cost descending, then alphabetically
+  // Sort by cost ascending, then alphabetically
   availableCards.sort((a, b) => {
     if (a.cost !== b.cost) {
-      return b.cost - a.cost; // Higher cost first
+      return a.cost - b.cost; // Lower cost first
     }
     return a.name.localeCompare(b.name); // Alphabetical
   });

--- a/packages/core/tests/presentation-move-options.test.ts
+++ b/packages/core/tests/presentation-move-options.test.ts
@@ -396,7 +396,7 @@ describe('generateRemodelStep2Options', () => {
     expect(options[0].description).toContain('No cards available');
   });
 
-  it('should sort options by cost descending', () => {
+  it('should sort options by cost ascending', () => {
     const supply = new Map<CardName, number>([
       ['Copper', 46],      // $0
       ['Silver', 40],      // $3
@@ -404,10 +404,9 @@ describe('generateRemodelStep2Options', () => {
     ]);
     const options = generateRemodelStep2Options(4, supply);
 
-    // Check descending cost order (assuming we can access getCard)
+    // Check ascending cost order (consistent with rest of game)
     for (let i = 0; i < options.length - 1; i++) {
-      // This test will need card cost lookup - may need adjustment
-      expect(options[i].details.gainCost).toBeGreaterThanOrEqual(options[i + 1].details.gainCost);
+      expect(options[i].details.gainCost).toBeLessThanOrEqual(options[i + 1].details.gainCost);
     }
   });
 


### PR DESCRIPTION
Changed sorting for gain card options to be ascending (lowest cost first) instead of descending (highest cost first) to match consistency with the rest of the game UI.

Changes:
- Updated generateRemodelStep2Options() to sort by cost ascending
- Updated generateMineStep2Options() to sort by cost ascending
- Updated generateWorkshopOptions() to sort by cost ascending
- Updated test to expect ascending order instead of descending

Affected cards: Remodel, Mine, Workshop, Feast

Fixes #11