### PR TITLE
Add TDD workflow enforcement hook and CLAUDE.md checkpoint

### DIFF
--- a/.claude/hooks/tdd-reminder.py
+++ b/.claude/hooks/tdd-reminder.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""
+TDD Reminder Hook
+
+Triggers before Edit/Write on production code files to remind about TDD workflow.
+This hook does NOT block edits - it outputs a reminder that Claude will see.
+"""
+
+import json
+import sys
+import re
+
+def is_production_code(file_path: str) -> bool:
+    """Check if file is production code (not test, not config, not docs)."""
+    if not file_path:
+        return False
+
+    # Must be in packages/*/src/ directory
+    if not re.search(r'packages/[^/]+/src/', file_path):
+        return False
+
+    # Exclude test files
+    if '.test.' in file_path or '.spec.' in file_path or '/tests/' in file_path:
+        return False
+
+    # Exclude type definition files that are just interfaces
+    if file_path.endswith('.d.ts'):
+        return False
+
+    # Must be a code file
+    if not file_path.endswith(('.ts', '.tsx', '.js', '.jsx')):
+        return False
+
+    return True
+
+
+def main():
+    try:
+        input_data = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        sys.exit(0)  # Don't block on parse errors
+
+    tool_input = input_data.get("tool_input", {})
+    file_path = tool_input.get("file_path", "")
+
+    if is_production_code(file_path):
+        # Output reminder to stderr (Claude sees this)
+        print("""
+================================================================================
+WORKFLOW REMINDER: You are editing production code.
+
+This project follows: Requirements -> Tests -> Implementation
+
+Before proceeding, verify:
+  1. Are requirements defined? (Check @req tags in tests or GitHub issues)
+  2. Is there a failing test that defines this change?
+  3. Have you run 'npm test' to confirm the current state?
+
+If this is a bug fix: Write a test that reproduces the bug FIRST.
+If this is a new feature: Define requirements, then write failing tests FIRST.
+
+Consider using:
+  - test-architect agent: For writing requirements and tests
+  - dev-agent: For implementing code to make tests pass
+
+File: {}
+================================================================================
+""".format(file_path), file=sys.stderr)
+
+    # Always allow the edit (exit 0) - this is advisory, not blocking
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/tdd-reminder.py\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,41 @@
 # CLAUDE.md
 
-**Status**: ACTIVE | **Phase**: 4 | **Last-Updated**: 2025-12-21
+**Status**: ACTIVE | **Phase**: 4 | **Last-Updated**: 2025-12-23
+
+---
+
+## STOP: Development Workflow Checkpoint
+
+**This project follows: Requirements → Tests → Implementation**
+
+**Before editing ANY production code** (`packages/*/src/*.ts`), verify:
+
+| Check | Question |
+|-------|----------|
+| 1. Requirements defined? | Are the requirements clear? (Check `@req` tags in tests or GitHub issues) |
+| 2. Test exists? | Is there a failing test that defines what you're about to implement? |
+| 3. Tests run? | Have you run `npm test` to confirm the current state? |
+| 4. Bug fix? | If fixing a bug, did you write a test that reproduces it FIRST? |
+
+**If you answered "no" to any of these: STOP.**
+
+### Workflow by Task Type
+
+| Task | Workflow |
+|------|----------|
+| **New feature** | 1. Define requirements → 2. Write failing tests with `@req` tags → 3. Implement |
+| **Bug fix** | 1. Write test reproducing bug → 2. Verify test fails → 3. Fix → 4. Verify test passes |
+| **Refactor** | 1. Ensure tests exist → 2. Run tests (green) → 3. Refactor → 4. Run tests (still green) |
+
+### Agent Responsibilities
+
+- **test-architect**: Owns requirements and tests. Use for defining what code should do.
+- **dev-agent**: Owns implementation. Use for writing production code to make tests pass.
+
+This does NOT apply to:
+- Documentation changes
+- Test file changes (that's test-architect's job)
+- Configuration changes
 
 ---
 


### PR DESCRIPTION
## Summary

Implements automated reminders to help maintain the Requirements → Tests → Implementation workflow discipline.

## Changes

### 1. PreToolUse Hook (`.claude/hooks/tdd-reminder.py`)

A hook that triggers before Edit/Write on production code files:
- Detects edits to `packages/*/src/*.ts` (excluding test files)
- Outputs a workflow reminder to stderr (visible to Claude)
- Advisory only - does not block edits
- Reminds about requirements, tests, and proper workflow

### 2. Hook Configuration (`.claude/settings.json`)

Configures the PreToolUse hook to trigger on Edit|Write tools.

### 3. CLAUDE.md "STOP: Development Workflow Checkpoint"

Added prominent section at the top of CLAUDE.md with:
- Checklist format for quick verification
- Workflow by task type (new feature, bug fix, refactor)
- Agent responsibilities (test-architect vs dev-agent)
- Clear guidance on what applies vs doesn't apply

## Why This Is Needed

The TDD/requirements workflow was being skipped when focused on completing tasks quickly. This provides:
1. **Automatic reminders** at the right moment (when editing production code)
2. **Prominent documentation** that's hard to miss
3. **Clear guidance** on the expected workflow

## Example Hook Output

```
================================================================================
WORKFLOW REMINDER: You are editing production code.

This project follows: Requirements -> Tests -> Implementation

Before proceeding, verify:
  1. Are requirements defined? (Check @req tags in tests or GitHub issues)
  2. Is there a failing test that defines this change?
  3. Have you run 'npm test' to confirm the current state?
...
================================================================================
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)