### PR TITLE
Fix Moneylender pendingEffect stuck state (issue #79)

### DIFF
--- a/packages/core/src/game.ts
+++ b/packages/core/src/game.ts
@@ -2444,6 +2444,19 @@ export class GameEngine {
         break;
       }
 
+      case 'trash_copper': {
+        // Moneylender: optionally trash a Copper from hand for +3 coins
+        const hasCopperInHand = player.hand.includes('Copper');
+
+        if (hasCopperInHand) {
+          // Option to trash Copper
+          moves.push({ type: 'trash_cards', cards: ['Copper'] });
+        }
+        // Option to skip/decline (always available)
+        moves.push({ type: 'trash_cards', cards: [] });
+        break;
+      }
+
       case 'trash_cards': {
         // Chapel: trash up to 4 cards (any combination)
         // Generate all possible combinations of cards to trash


### PR DESCRIPTION
## Summary
- Added missing `'trash_copper'` case to `getValidMovesForPendingEffect` switch statement
- When Moneylender is played with Copper in hand, valid moves now correctly include options to trash Copper or skip
- Resolves the "stuck state" where no valid moves were available after playing Moneylender

## Root Cause
The `handleMoneylender` function correctly sets `pendingEffect: { card: 'Moneylender', effect: 'trash_copper' }`, but `getValidMovesForPendingEffect` had no `case 'trash_copper':` handler, resulting in an empty moves array.

## Test Plan
- [x] Added `UT-MONEYLENDER-4` test that verifies `getValidMoves` returns trash options after playing Moneylender
- [x] All 14 trashing tests pass
- [x] Build succeeds

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)