### PR TITLE
Fix #103: SSOT violation in pending effect options

### DIFF
--- a/packages/cli/tests/pending-effect-ssot.test.ts
+++ b/packages/cli/tests/pending-effect-ssot.test.ts
@@ -7,8 +7,8 @@ import { GameEngine, GameState, generateMoveOptions } from '@principality/core';
 // @why: Prevent wrong moves from being executed when user selects from menu
 // @level: integration
 
-// @skip: Bug #37 - These tests intentionally capture SSOT violations that need fixing
-describe.skip('Pending Effect SSOT Violation (Bug #37, #12)', () => {
+// Bug #37 - Testing SSOT fix
+describe('Pending Effect SSOT Violation (Bug #37, #12)', () => {
   let engine: GameEngine;
 
   beforeEach(() => {

--- a/packages/core/src/presentation/move-options.ts
+++ b/packages/core/src/presentation/move-options.ts
@@ -349,7 +349,11 @@ export function generateChapelOptions(hand: readonly CardName[], maxTrash: numbe
  * Player chooses which card to trash
  *
  * @param hand - Player's current hand
- * @returns Array of options for each card in hand
+ * @returns Array of options for each UNIQUE card type in hand
+ *
+ * @fix: Issue #103 - Deduplicate to match getValidMoves() behavior
+ * Since all cards of the same type are functionally identical for Remodel,
+ * we show one option per card type, not per card instance.
  */
 export function generateRemodelStep1Options(hand: readonly CardName[]): MoveOption[] {
   if (hand.length === 0) {
@@ -365,7 +369,10 @@ export function generateRemodelStep1Options(hand: readonly CardName[]): MoveOpti
     ];
   }
 
-  return hand.map((card, idx) => {
+  // Deduplicate: only one option per card type (matches getValidMoves behavior)
+  const uniqueCards = Array.from(new Set(hand));
+
+  return uniqueCards.map((card, idx) => {
     const cardDef = getCard(card);
     const maxGainCost = cardDef.cost + 2;
 
@@ -438,7 +445,11 @@ export function generateRemodelStep2Options(
  * Player chooses which treasure to trash
  *
  * @param hand - Player's current hand
- * @returns Array of treasure options
+ * @returns Array of UNIQUE treasure options
+ *
+ * @fix: Issue #103 - Deduplicate to match getValidMoves() behavior
+ * Since all treasures of the same type are functionally identical for Mine,
+ * we show one option per treasure type, not per treasure instance.
  */
 export function generateMineStep1Options(hand: readonly CardName[]): MoveOption[] {
   // Filter hand for treasures only
@@ -457,7 +468,10 @@ export function generateMineStep1Options(hand: readonly CardName[]): MoveOption[
     ];
   }
 
-  return treasures.map((card, idx) => {
+  // Deduplicate: only one option per treasure type (matches getValidMoves behavior)
+  const uniqueTreasures = Array.from(new Set(treasures));
+
+  return uniqueTreasures.map((card, idx) => {
     const cardDef = getCard(card);
     const maxGainCost = cardDef.cost + 3;
 


### PR DESCRIPTION
## Summary

Fixes the Single Source of Truth (SSOT) violation where `getValidMoves()` and `generateMoveOptions()` produced different array lengths for pending effects with duplicate cards in hand.

**Root Cause:** 
- `getValidMoves()` in `game.ts` deduplicated cards using `Array.from(new Set(player.hand))`
- `generateRemodelStep1Options()` and `generateMineStep1Options()` in `move-options.ts` did not deduplicate

**Impact:**
- Display showed 4 options (e.g., Silver, Estate, Silver, Cellar)
- Execution only had 3 valid moves (Silver, Estate, Cellar)
- User selecting option 4 would fail or execute wrong move

## Changes

- `generateRemodelStep1Options`: Added deduplication before mapping
- `generateMineStep1Options`: Added deduplication before mapping  
- Enabled `pending-effect-ssot.test.ts` (was skipped, all 5 tests now pass)

## Test plan

- [x] All 5 SSOT tests pass
- [x] Core package: 872 tests pass (44 suites)
- [x] CLI package: 789 tests pass (30 suites, 2 pre-existing failures from #102)
- [x] No regressions introduced

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)