### PR TITLE
Add API server, web game tools, Claude AI player, and fix 6 gameplay bugs

### DIFF
--- a/packages/api-server/src/__tests__/library-pending-effect.test.ts
+++ b/packages/api-server/src/__tests__/library-pending-effect.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Library Pending Effect Tests
+ *
+ * Verifies that filterStateForHuman passes through the drawnCard field
+ * from the core PendingEffect to the ClientPendingEffect.
+ *
+ * @req GH-128 - Library drawnCard not passed through state filter
+ */
+
+import { filterStateForHuman } from '../services/state-filter';
+import type { GameState } from '@principality/core';
+
+function makeMinimalState(overrides: Partial<GameState> = {}): GameState {
+  const base: GameState = {
+    players: [
+      {
+        hand: ['Copper', 'Copper', 'Copper', 'Estate', 'Library'],
+        drawPile: ['Silver', 'Gold'],
+        discardPile: [],
+        inPlay: [],
+        actions: 1,
+        buys: 1,
+        coins: 0,
+      },
+      {
+        hand: ['Copper', 'Copper', 'Copper', 'Estate', 'Estate'],
+        drawPile: ['Silver'],
+        discardPile: [],
+        inPlay: [],
+        actions: 1,
+        buys: 1,
+        coins: 0,
+      },
+    ],
+    supply: new Map([
+      ['Copper', 46],
+      ['Silver', 40],
+      ['Gold', 30],
+      ['Estate', 8],
+      ['Duchy', 8],
+      ['Province', 8],
+      ['Library', 10],
+    ]),
+    currentPlayer: 0,
+    phase: 'action' as const,
+    turnNumber: 1,
+    gameLog: [],
+    trash: [],
+    pendingEffect: undefined,
+    seed: 'test-seed',
+  };
+  return { ...base, ...overrides };
+}
+
+describe('Library pending effect - drawnCard passthrough', () => {
+  it('should include drawnCard in ClientPendingEffect when Library draws an action card', () => {
+    const state = makeMinimalState({
+      pendingEffect: {
+        card: 'Library',
+        effect: 'library_set_aside',
+        drawnCard: 'Village',
+        targetPlayer: 0,
+      },
+    });
+
+    const clientState = filterStateForHuman(state, 0);
+
+    expect(clientState.pendingEffect).toBeDefined();
+    expect(clientState.pendingEffect!.card).toBe('Library');
+    expect(clientState.pendingEffect!.effect).toBe('library_set_aside');
+    expect(clientState.pendingEffect!.drawnCard).toBe('Village');
+  });
+
+  it('should have drawnCard undefined when pendingEffect has no drawnCard', () => {
+    const state = makeMinimalState({
+      pendingEffect: {
+        card: 'Chapel',
+        effect: 'trash_cards',
+        maxTrash: 4,
+      },
+    });
+
+    const clientState = filterStateForHuman(state, 0);
+
+    expect(clientState.pendingEffect).toBeDefined();
+    expect(clientState.pendingEffect!.card).toBe('Chapel');
+    expect(clientState.pendingEffect!.drawnCard).toBeUndefined();
+  });
+
+  it('should not include pendingEffect when none is set', () => {
+    const state = makeMinimalState();
+
+    const clientState = filterStateForHuman(state, 0);
+
+    expect(clientState.pendingEffect).toBeUndefined();
+  });
+});

--- a/packages/api-server/src/services/state-filter.ts
+++ b/packages/api-server/src/services/state-filter.ts
@@ -86,6 +86,7 @@ export function filterStateForHuman(
           : state.currentPlayer,
       maxTrash: state.pendingEffect.maxTrash,
       maxGainCost: state.pendingEffect.maxGainCost,
+      drawnCard: state.pendingEffect.drawnCard,
     };
   }
 

--- a/packages/api-server/src/types/api.ts
+++ b/packages/api-server/src/types/api.ts
@@ -165,6 +165,8 @@ export interface ClientPendingEffect {
   maxTrash?: number;
   /** Maximum cost of card that can be gained (if applicable) */
   maxGainCost?: number;
+  /** The action card drawn by Library that the player must decide on */
+  drawnCard?: CardName;
 }
 
 /**

--- a/packages/core/src/presentation/move-descriptions.ts
+++ b/packages/core/src/presentation/move-descriptions.ts
@@ -71,8 +71,8 @@ export function getMoveDescription(move: Move): string {
       return move.choice ? 'Shuffle deck into discard' : 'Keep deck as is';
 
     case 'library_set_aside':
-      return move.cards && move.cards.length > 0
-        ? `Set aside ${move.cards[0]}`
+      return move.card
+        ? `Set aside ${move.card}`
         : 'Set aside action card';
 
     default:
@@ -137,8 +137,8 @@ export function getMoveDescriptionCompact(move: Move): string {
         : 'Select treasure to trash';
 
     case 'library_set_aside':
-      return move.cards && move.cards.length > 0
-        ? `Set aside: ${move.cards[0]}`
+      return move.card
+        ? `Set aside: ${move.card}`
         : 'Set aside action card';
 
     case 'select_action_for_throne':
@@ -248,8 +248,8 @@ export function getMoveCommand(move: Move): string {
       return `chancellor_decision ${move.choice ? 'yes' : 'no'}`;
 
     case 'library_set_aside':
-      return move.cards && move.cards.length > 0
-        ? `library_set_aside ${move.cards[0]}`
+      return move.card
+        ? `library_set_aside ${move.card}`
         : 'library_set_aside';
 
     default:

--- a/packages/core/src/presentation/move-options.ts
+++ b/packages/core/src/presentation/move-options.ts
@@ -158,8 +158,8 @@ export function formatMoveCommand(move: Move): string {
       return `select_treasure_to_trash ${move.card}`;
 
     case 'library_set_aside':
-      return move.cards && move.cards.length > 0
-        ? `library_set_aside ${move.cards[0]}`
+      return move.card
+        ? `library_set_aside ${move.card}`
         : 'library_set_aside';
 
     case 'select_action_for_throne':
@@ -620,14 +620,14 @@ export function generateLibraryOptions(card: CardName): MoveOption[] {
   return [
     {
       index: 1,
-      move: { type: 'library_set_aside', cards: [card], choice: true },
+      move: { type: 'library_set_aside', card, choice: true },
       description: `Set aside: ${card} (skip it, discard at end)`,
       cardNames: [card],
       details: { action: 'set_aside' }
     },
     {
       index: 2,
-      move: { type: 'library_set_aside', cards: [card], choice: false },
+      move: { type: 'library_set_aside', card, choice: false },
       description: `Keep: ${card} in hand`,
       cardNames: [card],
       details: { action: 'keep' }

--- a/packages/core/src/presentation/move-parser.ts
+++ b/packages/core/src/presentation/move-parser.ts
@@ -81,6 +81,40 @@ export function parseMove(moveStr: string, state: GameState): ParseMoveResult {
         error: `Card at index ${index} (${cardName}) is not playable`
       };
     }
+
+    // If not a valid index, try treating the argument as a card name
+    if (isNaN(index)) {
+      const normalizedName = capitalizeCardName(indexStr);
+
+      if (player.hand.includes(normalizedName)) {
+        if (isActionCard(normalizedName)) {
+          return {
+            success: true,
+            move: {
+              type: 'play_action',
+              card: normalizedName
+            }
+          };
+        } else if (isTreasureCard(normalizedName)) {
+          return {
+            success: true,
+            move: {
+              type: 'play_treasure',
+              card: normalizedName
+            }
+          };
+        }
+        return {
+          success: false,
+          error: `"${normalizedName}" is not a playable card`
+        };
+      }
+      return {
+        success: false,
+        error: `"${normalizedName}" is not in hand`
+      };
+    }
+
     return {
       success: false,
       error: `Invalid index: ${indexStr}. Must be 0-${player.hand.length - 1}`
@@ -467,7 +501,7 @@ export function parseMove(moveStr: string, state: GameState): ParseMoveResult {
       success: true,
       move: {
         type: 'library_set_aside',
-        cards: [normalizedName]
+        card: normalizedName
       }
     };
   }

--- a/packages/core/tests/getValidMoves-pending-effects.test.ts
+++ b/packages/core/tests/getValidMoves-pending-effects.test.ts
@@ -852,8 +852,8 @@ describe('getValidMoves() with pending effects', () => {
         ...state,
         pendingEffect: {
           card: 'Library',
-          effect: 'library_set_aside'
-          // Revealed action would be tracked in pendingEffect context
+          effect: 'library_set_aside',
+          drawnCard: 'Village'
         }
       };
 

--- a/packages/core/tests/move-parser-card-names.test.ts
+++ b/packages/core/tests/move-parser-card-names.test.ts
@@ -1,0 +1,160 @@
+/**
+ * @file Move Parser Card Name Tests
+ * @status RED (tests will FAIL until parseMove() handles card name arguments)
+ *
+ * ROOT CAUSE:
+ * - parseMove("play Village", state) fails because "play " handler only tries parseInt()
+ * - When parseInt("Village") returns NaN, the handler returns an error
+ * - Need to fall back to card name lookup when index parsing fails
+ *
+ * @req: parseMove() must handle card names in "play CARD" format
+ * @impact: Web API sends "play Copper" / "play Village" but parser only handles "play 0"
+ */
+
+import { GameEngine, parseMove, GameState, ParseMoveResult } from '@principality/core';
+
+describe('Move Parser: Card Name Arguments', () => {
+  let engine: GameEngine;
+
+  beforeEach(() => {
+    engine = new GameEngine('parser-card-name-test');
+  });
+
+  const createTestState = (overrides?: Partial<GameState>): GameState => {
+    const baseState = engine.initializeGame(1);
+    return {
+      ...baseState,
+      phase: 'action',
+      players: [{
+        ...baseState.players[0],
+        hand: ['Copper', 'Silver', 'Village', 'Smithy', 'Estate'],
+        drawPile: ['Duchy'],
+        discardPile: [],
+        inPlay: [],
+        actions: 1,
+        buys: 1,
+        coins: 0
+      }],
+      ...overrides
+    };
+  };
+
+  describe('play CARD - treasure cards', () => {
+    /**
+     * @req: "play Copper" should resolve to play_treasure move
+     * @edge: Case insensitive, card must be in hand
+     */
+
+    test('should parse "play Copper" as play_treasure', () => {
+      const state = createTestState({ phase: 'buy' });
+      const result: ParseMoveResult = parseMove('play Copper', state);
+
+      expect(result.success).toBe(true);
+      expect(result.move).toEqual({
+        type: 'play_treasure',
+        card: 'Copper'
+      });
+    });
+
+    test('should parse "play Silver" as play_treasure', () => {
+      const state = createTestState({ phase: 'buy' });
+      const result = parseMove('play Silver', state);
+
+      expect(result.success).toBe(true);
+      expect(result.move).toEqual({
+        type: 'play_treasure',
+        card: 'Silver'
+      });
+    });
+  });
+
+  describe('play CARD - action cards', () => {
+    /**
+     * @req: "play Village" should resolve to play_action move
+     * @edge: Only during action phase, card must be in hand
+     */
+
+    test('should parse "play Village" as play_action', () => {
+      const state = createTestState();
+      const result = parseMove('play Village', state);
+
+      expect(result.success).toBe(true);
+      expect(result.move).toEqual({
+        type: 'play_action',
+        card: 'Village'
+      });
+    });
+
+    test('should parse "play Smithy" as play_action', () => {
+      const state = createTestState();
+      const result = parseMove('play Smithy', state);
+
+      expect(result.success).toBe(true);
+      expect(result.move).toEqual({
+        type: 'play_action',
+        card: 'Smithy'
+      });
+    });
+  });
+
+  describe('case insensitivity', () => {
+    /**
+     * @req: Card names should be case insensitive
+     */
+
+    test('should parse "play copper" (lowercase) correctly', () => {
+      const state = createTestState({ phase: 'buy' });
+      const result = parseMove('play copper', state);
+
+      expect(result.success).toBe(true);
+      expect(result.move).toEqual({
+        type: 'play_treasure',
+        card: 'Copper'
+      });
+    });
+
+    test('should parse "play village" (lowercase) correctly', () => {
+      const state = createTestState();
+      const result = parseMove('play village', state);
+
+      expect(result.success).toBe(true);
+      expect(result.move).toEqual({
+        type: 'play_action',
+        card: 'Village'
+      });
+    });
+  });
+
+  describe('error cases', () => {
+    /**
+     * @req: Cards not in hand should fail
+     * @edge: Non-playable cards (Victory) should fail
+     */
+
+    test('should reject card not in hand', () => {
+      const state = createTestState({
+        players: [{
+          ...createTestState().players[0],
+          hand: ['Copper']
+        }]
+      });
+      const result = parseMove('play Village', state);
+
+      expect(result.success).toBe(false);
+    });
+
+    test('should reject non-existent card name', () => {
+      const state = createTestState();
+      const result = parseMove('play Nonexistent', state);
+
+      expect(result.success).toBe(false);
+    });
+
+    test('should reject victory card (not playable)', () => {
+      const state = createTestState();
+      const result = parseMove('play Estate', state);
+
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/packages/core/tests/move-parser-pending-effects.test.ts
+++ b/packages/core/tests/move-parser-pending-effects.test.ts
@@ -515,7 +515,7 @@ describe('Move Parser: Pending Effect Commands', () => {
       expect(result.success).toBe(true);
       expect(result.move).toEqual({
         type: 'library_set_aside',
-        cards: ['Village']
+        card: 'Village'
       });
     });
 
@@ -526,7 +526,7 @@ describe('Move Parser: Pending Effect Commands', () => {
       expect(result.success).toBe(true);
       expect(result.move).toEqual({
         type: 'library_set_aside',
-        cards: ['Throne Room']
+        card: 'Throne Room'
       });
     });
 

--- a/packages/core/tests/presentation-move-options.test.ts
+++ b/packages/core/tests/presentation-move-options.test.ts
@@ -127,7 +127,7 @@ describe('Helper Functions', () => {
     });
 
     it('should format library_set_aside move', () => {
-      const move = { type: 'library_set_aside' as const, cards: ['Village'], choice: true };
+      const move = { type: 'library_set_aside' as const, card: 'Village' as const, choice: true };
       const command = formatMoveCommand(move);
 
       expect(command).toBe('library_set_aside Village');

--- a/packages/core/tests/presentation.test.ts
+++ b/packages/core/tests/presentation.test.ts
@@ -1278,7 +1278,7 @@ describe('Presentation Layer: Move Descriptions', () => {
     });
 
     test('should handle library_set_aside with card', () => {
-      const move: Move = { type: 'library_set_aside', cards: ['Village'] };
+      const move: Move = { type: 'library_set_aside', card: 'Village' };
       expect(getMoveDescriptionCompact(move)).toBe('Set aside: Village');
     });
 
@@ -1396,7 +1396,7 @@ describe('Presentation Layer: Move Descriptions', () => {
     });
 
     test('should generate library_set_aside command', () => {
-      const move: Move = { type: 'library_set_aside', cards: ['Village'] };
+      const move: Move = { type: 'library_set_aside', card: 'Village' };
       expect(getMoveCommand(move)).toBe('library_set_aside Village');
     });
   });

--- a/packages/web/src/components/PhaseIndicator.tsx
+++ b/packages/web/src/components/PhaseIndicator.tsx
@@ -14,7 +14,7 @@ interface PhaseIndicatorProps {
 function canPlayAllTreasures(validMoves: ValidMove[]): boolean {
   return validMoves.some((vm) => {
     const move = vm.move as { type: string };
-    return move.type === 'play_all_treasures';
+    return move.type === 'play_treasure';
   });
 }
 

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -112,6 +112,8 @@ export interface ClientPendingEffect {
   respondingPlayer: number;
   maxTrash?: number;
   maxGainCost?: number;
+  /** The action card drawn by Library that the player must decide on */
+  drawnCard?: string;
 }
 
 export interface ValidMove {


### PR DESCRIPTION
## Summary

- **API server** (`packages/api-server`): Hono-based HTTP API with WebSocket support, game registry, state filtering, turn coordination, and Manual AI Mode
- **Web game MCP tools**: `web_game_create`, `web_game_observe`, `web_game_execute` for browser-based gameplay
- **Claude AI player**: Anthropic SDK integration with Big Money fallback strategy, AI prompt generation, and configurable model selection
- **6 bug fixes** (closes #99, #124, #125, #126, #128):
  - Library card drawnCard passthrough in state filter (#128)
  - Move parser accepts card names like "play Copper" not just indices (#126)
  - Play All Treasures button visibility (#125)
  - Treasure card clicking (#124)
  - Witch per-opponent Curse distribution feedback (#99)
- Documentation updates: timeless ROADMAP, API reference, Phase 5 requirements

## Test plan

- [x] `npm test` — 883 core tests, 775 mcp-server tests, 144 api-server tests pass (0 failures)
- [x] `npm run build` — all packages compile cleanly
- [x] Issues #99, #100, #124, #125, #126, #127, #128 closed with evidence

🤖 Generated with [Claude Code](https://claude.com/claude-code)